### PR TITLE
add support for ConnectionPool

### DIFF
--- a/redis-rack.gemspec
+++ b/redis-rack.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha',    '~> 0.14.0'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'redis-store-testing'
+  s.add_development_dependency 'connection_pool',     '~> 1.2.0'
 end
 


### PR DESCRIPTION
Identical to [`ActiveSupport::Cache::RedisStore`](https://github.com/redis-store/redis-activesupport/blob/master/lib/active_support/cache/redis_store.rb#L36)

Side note:
While implementing this I got a question about both `ActiveSupport::Cache::RedisStore` and `Rack::Session::Redis`

Say I have a redis connection pool in my app, and I want to use it for cache or session. Now my connection pool is probably something like
```ruby
$redis_connection_pool = ConnectionPool.new { Redis.new }
```
This won't work because `Rack::Session::Redis` expects the underlying connection be of class `Redis::Store` and not `Redis` and their interfaces are not compatible.
What is the proper decision here?