### PR TITLE
Loosen dependancy on Rack to allow 1.5 and 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 script: 'bundle exec rake'
 rvm:
   - 2.0.0
+  - 2.1.7
+  - 2.2.3
   - ruby-head
   - rbx-19mode
   - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 script: 'bundle exec rake'
 rvm:
-  - 1.9.3
   - 2.0.0
   - ruby-head
   - rbx-19mode

--- a/redis-rack.gemspec
+++ b/redis-rack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'rack',          '~> 1.5'
+  s.add_runtime_dependency 'rack',          '> 1.5', '< 3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
Rails 5 beta requires Rack 2.x and this gem is unusable unless can use Rack 2.x