### PR TITLE
Drop support for Rubinius 1.9 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ script: 'bundle exec rake'
 rvm:
   - 2.2.3
   - 2.3.1
-  - rbx-19mode
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
1.9.x is EOL in MRI Ruby Land, and Rubinius 1.9 mode isn't really used
much anymore. This should make the builds pass again.