### PR TITLE
Rescue ::Redis::CannotConnectError to gracefully handle loss of redis connection

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -14,7 +14,6 @@ module Rack
         super
 
         @mutex = Mutex.new
-        @raise_errors = options[:raise_errors] || false
         @pool = if @default_options[:pool]
                   raise "pool must be an instance of ConnectionPool" unless @default_options[:pool].is_a?(ConnectionPool)
                   @pooled = true
@@ -79,7 +78,6 @@ module Rack
           warn "#{self} is unable to find Redis server."
           warn $!.inspect
         end
-        raise if raise_errors?
         default
       ensure
         @mutex.unlock if @mutex.locked?

--- a/test/rack/session/redis_test.rb
+++ b/test/rack/session/redis_test.rb
@@ -347,6 +347,26 @@ describe Rack::Session::Redis do
     end
   end
 
+  describe "on a connection failure" do
+    it "#get_session returns the default" do
+      redis_store = Rack::Session::Redis.new("redis://127.0.0.1:6380/1")
+      redis_store.stubs(:with).raises(::Redis::CannotConnectError)
+      env = {'rack.session.options' => {} }
+      redis_store.get_session(env, 'sid').must_equal([nil, {}])
+    end
+  end
+
+  describe "on a connection failure with raise_errors: true" do
+    it "#get_session raises the error" do
+      redis_store = Rack::Session::Redis.new("redis://127.0.0.1:6380/1", raise_errors: true)
+      redis_store.stubs(:with).raises(::Redis::CannotConnectError)
+      env = {'rack.session.options' => {} }
+      assert_raises(::Redis::CannotConnectError) do
+        redis_store.get_session(env, 'sid')
+      end
+    end
+  end
+
   private
     def with_pool_management(*args)
       yield simple(*args)

--- a/test/rack/session/redis_test.rb
+++ b/test/rack/session/redis_test.rb
@@ -348,22 +348,18 @@ describe Rack::Session::Redis do
   end
 
   describe "on a connection failure" do
-    it "#get_session returns the default" do
+    it "#get_session returns the default when Redis::CannotConnectError is raised" do
       redis_store = Rack::Session::Redis.new("redis://127.0.0.1:6380/1")
       redis_store.stubs(:with).raises(::Redis::CannotConnectError)
       env = {'rack.session.options' => {} }
       redis_store.get_session(env, 'sid').must_equal([nil, {}])
     end
-  end
 
-  describe "on a connection failure with raise_errors: true" do
-    it "#get_session raises the error" do
-      redis_store = Rack::Session::Redis.new("redis://127.0.0.1:6380/1", raise_errors: true)
-      redis_store.stubs(:with).raises(::Redis::CannotConnectError)
+    it "#get_session returns the default when Errno::ECONNREFUSED is raised" do
+      redis_store = Rack::Session::Redis.new("redis://127.0.0.1:6380/1")
+      redis_store.stubs(:with).raises(Errno::ECONNREFUSED)
       env = {'rack.session.options' => {} }
-      assert_raises(::Redis::CannotConnectError) do
-        redis_store.get_session(env, 'sid')
-      end
+      redis_store.get_session(env, 'sid').must_equal([nil, {}])
     end
   end
 


### PR DESCRIPTION
Rescue ::Redis::CannotConnectError to handle loss of redis connection. By default the default to the #with_lock is returned. However, the option to raise errors is provided as well.