### PR TITLE
Refactor connection_pool code

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -1,42 +1,29 @@
 require 'rack/session/abstract/id'
 require 'redis-store'
 require 'thread'
+require 'redis/rack/connection'
 
 module Rack
   module Session
     class Redis < Abstract::ID
-      attr_reader :mutex, :pool
+      attr_reader :mutex
 
-      DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge \
+      DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge(
         :redis_server => 'redis://127.0.0.1:6379/0/rack:session'
+      )
 
       def initialize(app, options = {})
         super
 
         @mutex = Mutex.new
-        @pool = if @default_options[:pool]
-                 raise "pool must be an instance of ConnectionPool" unless @default_options[:pool].is_a?(ConnectionPool)
-                  @pooled = true
-                  @default_options[:pool]
-                elsif [:pool_size, :pool_timeout].any? { |key| @default_options.has_key?(key) }
-                  pool_options           = {}
-                  pool_options[:size]    = options[:pool_size] if options[:pool_size]
-                  pool_options[:timeout] = options[:pool_timeout] if options[:pool_timeout]
-                  @pooled = true
-                  ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(@default_options[:redis_server]) } 
-                else
-                  @default_options.has_key?(:redis_store) ? 
-                    @default_options[:redis_store] :
-                    ::Redis::Store::Factory.create(@default_options[:redis_server])
-
-                end
+        @conn = ::Redis::Rack::Connection.new(@default_options)
       end
 
       def generate_unique_sid(session)
         loop do
           sid = generate_sid
           first = with do |c|
-            [*c.setnx(sid, session, @default_options)].first
+            [*c.setnx(sid, session, @config)].first
           end
           break sid if [1, true].include?(first)
         end
@@ -84,13 +71,8 @@ module Rack
       end
 
       def with(&block)
-        if @pooled
-          @pool.with(&block)
-        else
-          block.call(@pool)
-        end
+        @conn.with(&block)
       end
-
     end
   end
 end

--- a/lib/redis/rack/connection.rb
+++ b/lib/redis/rack/connection.rb
@@ -1,0 +1,42 @@
+class Redis
+  module Rack
+    class Connection
+      def initialize(options = {})
+        @options = options
+        @store = options[:redis_store]
+        @pool = options[:pool]
+
+        if @pool && !@pool.is_a?(ConnectionPool)
+          raise ArgumentError, "pool must be an instance of ConnectionPool"
+        end
+      end
+
+      def with(&block)
+        if pooled?
+          pool.with(&block)
+        else
+          block.call(store)
+        end
+      end
+
+      def pooled?
+        [:pool, :pool_size, :pool_timeout].any? { |key| @options.key?(key) }
+      end
+
+      def pool
+        @pool ||= ConnectionPool.new(pool_options) { store } if pooled?
+      end
+
+      def store
+        @store ||= Redis::Store::Factory.create(@options[:redis_server])
+      end
+
+      def pool_options
+        {
+          size: @options[:pool_size],
+          timeout: @options[:pool_timeout]
+        }
+      end
+    end
+  end
+end

--- a/test/rack/session/redis_test.rb
+++ b/test/rack/session/redis_test.rb
@@ -39,8 +39,9 @@ describe Rack::Session::Redis do
 
   it "can create it's own pool" do
     session_store = Rack::Session::Redis.new(incrementor, pool_size: 5, pool_timeout: 10)
-    session_store.pool.class.must_equal ::ConnectionPool
-    session_store.pool.instance_variable_get(:@size).must_equal 5
+    conn = session_store.instance_variable_get(:@conn)
+    conn.pool.class.must_equal ::ConnectionPool
+    conn.pool.instance_variable_get(:@size).must_equal 5
   end
 
   it "can create it's own pool using default Redis server" do
@@ -53,33 +54,35 @@ describe Rack::Session::Redis do
     session_store.with { |connection| connection.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)  }
   end
 
-
   it "can use a supplied pool" do
     session_store = Rack::Session::Redis.new(incrementor, pool: ::ConnectionPool.new(size: 1, timeout: 1) { ::Redis::Store::Factory.create("redis://127.0.0.1:6380/1")})
-    session_store.pool.class.must_equal ::ConnectionPool
-    session_store.pool.instance_variable_get(:@size).must_equal 1
+    conn = session_store.instance_variable_get(:@conn)
+    conn.pool.class.must_equal ::ConnectionPool
+    conn.pool.instance_variable_get(:@size).must_equal 1
   end
 
   it "uses the specified Redis store when provided" do
     store = ::Redis::Store::Factory.create('redis://127.0.0.1:6380/1')
     pool = Rack::Session::Redis.new(incrementor, :redis_store => store)
-    pool.pool.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
-    pool.pool.must_equal(store)
+    pool.with do |p|
+      p.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
+      p.must_equal(store)
+    end
   end
 
   it "uses the default Redis server and namespace when not provided" do
     pool = Rack::Session::Redis.new(incrementor)
-    pool.pool.to_s.must_match(/127\.0\.0\.1:6379 against DB 0 with namespace rack:session$/)
+    pool.with { |p| p.to_s.must_match(/127\.0\.0\.1:6379 against DB 0 with namespace rack:session$/) }
   end
 
   it "uses the specified namespace when provided" do
     pool = Rack::Session::Redis.new(incrementor, :redis_server => {:namespace => 'test:rack:session'})
-    pool.pool.to_s.must_match(/namespace test:rack:session$/)
+    pool.with { |p| p.to_s.must_match(/namespace test:rack:session$/) }
   end
 
   it "uses the specified Redis server when provided" do
     pool = Rack::Session::Redis.new(incrementor, :redis_server => 'redis://127.0.0.1:6380/1')
-    pool.pool.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
+    pool.with { |p| p.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/) }
   end
 
   it "creates a new cookie" do
@@ -229,15 +232,12 @@ describe Rack::Session::Redis do
   end
 
   it "does not hit with :skip option" do
-    with_pool_management(incrementor) do |pool|
-      skip = Rack::Utils::Context.new(pool, skip_session)
+    with_pool_management(incrementor) do |session_store|
+      skip = Rack::Utils::Context.new(session_store, skip_session)
       sreq = Rack::MockRequest.new(skip)
-
-      pool.instance_variable_set('@pool', MiniTest::Mock.new)
 
       res0 = sreq.get("/")
       res0.body.must_equal('{"counter"=>1}')
-      assert pool.pool.verify
     end
   end
 

--- a/test/redis/rack/connection_test.rb
+++ b/test/redis/rack/connection_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+require 'connection_pool'
+require 'redis/rack/connection'
+
+class Redis
+  module Rack
+    describe Connection do
+      def setup
+        @defaults = {
+          host: 'localhost'
+        }
+      end
+
+      it "can create it's own pool" do
+        conn = Connection.new @defaults.merge(pool_size: 5, pool_timeout: 10)
+
+        conn.pooled?.must_equal true
+        conn.pool.class.must_equal ConnectionPool
+        conn.pool.instance_variable_get(:@size).must_equal 5
+      end
+
+      it "can create it's own pool using default Redis server" do
+        conn = Connection.new @defaults.merge(pool_size: 5, pool_timeout: 10)
+
+        conn.pooled?.must_equal true
+
+        conn.with do |connection|
+          connection.to_s.must_match(/127\.0\.0\.1:6379 against DB 0$/)
+        end
+      end
+
+      it "can create it's own pool using provided Redis server" do
+        conn = Connection.new(redis_server: 'redis://127.0.0.1:6380/1', pool_size: 5, pool_timeout: 10)
+        conn.pooled?.must_equal true
+        conn.with do |connection|
+          connection.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
+        end
+      end
+
+      it "can use a supplied pool" do
+        pool = ConnectionPool.new size: 1, timeout: 1 do
+          ::Redis::Store::Factory.create('redis://127.0.0.1:6380/1')
+        end
+        conn = Connection.new pool: pool
+        conn.pooled?.must_equal true
+        conn.pool.class.must_equal ConnectionPool
+        conn.pool.instance_variable_get(:@size).must_equal 1
+      end
+
+      it "uses the specified Redis store when provided" do
+        store = ::Redis::Store::Factory.create('redis://127.0.0.1:6380/1')
+        conn = Connection.new(redis_store: store)
+
+        conn.pooled?.must_equal false
+        conn.store.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
+        conn.store.must_equal(store)
+      end
+
+      it "uses the specified Redis server when provided" do
+        conn = Connection.new(redis_server: 'redis://127.0.0.1:6380/1')
+
+        conn.pooled?.must_equal false
+        conn.store.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a `Redis::Rack::Connection` object for handling the instantiation
of a `Redis::Store` or a `ConnectionPool` if pool configuration is
given. Restores the purpose of `Rack::Session::Redis` to only implement
the session ID abstract API provided by Rack.