### PR TITLE
Create a :use_global_lock option to enable/ disable the global lock

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -70,12 +70,12 @@ module Rack
         end
       end
 
-      def use_global_lock?
-        @default_options.fetch(:use_global_lock, true)
+      def threadsafe?
+        @default_options.fetch(:threadsafe, true)
       end
 
       def with_lock(env, default=nil)
-        @mutex.lock if env['rack.multithread'] && use_global_lock?
+        @mutex.lock if env['rack.multithread'] && threadsafe?
         yield
       rescue Errno::ECONNREFUSED
         if $VERBOSE

--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -23,9 +23,9 @@ module Rack
                   pool_options[:size]    = options[:pool_size] if options[:pool_size]
                   pool_options[:timeout] = options[:pool_timeout] if options[:pool_timeout]
                   @pooled = true
-                  ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(@default_options[:redis_server]) } 
+                  ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(@default_options[:redis_server]) }
                 else
-                  @default_options.has_key?(:redis_store) ? 
+                  @default_options.has_key?(:redis_store) ?
                     @default_options[:redis_store] :
                     ::Redis::Store::Factory.create(@default_options[:redis_server])
 
@@ -70,8 +70,12 @@ module Rack
         end
       end
 
+      def use_global_lock?
+        @default_options.fetch(:use_global_lock, true)
+      end
+
       def with_lock(env, default=nil)
-        @mutex.lock if env['rack.multithread']
+        @mutex.lock if env['rack.multithread'] && use_global_lock?
         yield
       rescue Errno::ECONNREFUSED
         if $VERBOSE
@@ -94,4 +98,3 @@ module Rack
     end
   end
 end
-

--- a/test/rack/session/redis_test.rb
+++ b/test/rack/session/redis_test.rb
@@ -3,6 +3,24 @@ require 'rack/mock'
 require 'thread'
 require 'connection_pool'
 
+class MockMutex
+  attr_reader :was_locked
+
+  def initialize
+    @was_locked = false
+  end
+
+  def lock
+    @was_locked = true
+  end
+
+  def unlock
+  end
+
+  def locked?
+  end
+end
+
 describe Rack::Session::Redis do
   session_key = Rack::Session::Redis::DEFAULT_OPTIONS[:key]
   session_match = /#{session_key}=([0-9a-fA-F]+);/
@@ -53,7 +71,6 @@ describe Rack::Session::Redis do
     session_store.with { |connection| connection.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)  }
   end
 
-
   it "can use a supplied pool" do
     session_store = Rack::Session::Redis.new(incrementor, pool: ::ConnectionPool.new(size: 1, timeout: 1) { ::Redis::Store::Factory.create("redis://127.0.0.1:6380/1")})
     session_store.pool.class.must_equal ::ConnectionPool
@@ -80,6 +97,38 @@ describe Rack::Session::Redis do
   it "uses the specified Redis server when provided" do
     pool = Rack::Session::Redis.new(incrementor, :redis_server => 'redis://127.0.0.1:6380/1')
     pool.pool.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
+  end
+
+  it "uses a global lock by default" do
+    sesion_store = Rack::Session::Redis.new(incrementor)
+    sesion_store.use_global_lock?.must_equal(true)
+  end
+
+  it "locks the store mutex" do
+    mutex = MockMutex.new
+    sesion_store = Rack::Session::Redis.new(incrementor)
+    sesion_store.instance_variable_set(:@mutex, mutex)
+    was_yielded = false
+    sesion_store.with_lock({'rack.multithread' => true}) { was_yielded = true}
+    mutex.was_locked.must_equal(true)
+    was_yielded.must_equal(true)
+  end
+
+  describe "global lock disabled" do
+    it "can have the global lock disabled" do
+      sesion_store = Rack::Session::Redis.new(incrementor, :use_global_lock => false)
+      sesion_store.use_global_lock?.must_equal(false)
+    end
+
+    it "does not lock the store mutex" do
+      mutex = MockMutex.new
+      sesion_store = Rack::Session::Redis.new(incrementor, :use_global_lock => false)
+      sesion_store.instance_variable_set(:@mutex, mutex)
+      was_yielded = false
+      sesion_store.with_lock({'rack.multithread' => true}) { was_yielded = true}
+      mutex.was_locked.must_equal(false)
+      was_yielded.must_equal(true)
+    end
   end
 
   it "creates a new cookie" do

--- a/test/rack/session/redis_test.rb
+++ b/test/rack/session/redis_test.rb
@@ -81,9 +81,9 @@ describe Rack::Session::Redis do
     pool.pool.to_s.must_match(/127\.0\.0\.1:6380 against DB 1$/)
   end
 
-  it "uses a global lock by default" do
+  it "is threadsafe by default" do
     sesion_store = Rack::Session::Redis.new(incrementor)
-    sesion_store.use_global_lock?.must_equal(true)
+    sesion_store.threadsafe?.must_equal(true)
   end
 
   it "locks the store mutex" do
@@ -96,16 +96,16 @@ describe Rack::Session::Redis do
     was_yielded.must_equal(true)
   end
 
-  describe "global lock disabled" do
+  describe "threadsafe disabled" do
     it "can have the global lock disabled" do
-      sesion_store = Rack::Session::Redis.new(incrementor, :use_global_lock => false)
-      sesion_store.use_global_lock?.must_equal(false)
+      sesion_store = Rack::Session::Redis.new(incrementor, :threadsafe => false)
+      sesion_store.threadsafe?.must_equal(false)
     end
 
     it "does not lock the store mutex" do
       mutex = Mutex.new
       mutex.expects(:lock).never
-      sesion_store = Rack::Session::Redis.new(incrementor, :use_global_lock => false)
+      sesion_store = Rack::Session::Redis.new(incrementor, :threadsafe => false)
       sesion_store.instance_variable_set(:@mutex, mutex)
       was_yielded = false
       sesion_store.with_lock({'rack.multithread' => true}) { was_yielded = true}


### PR DESCRIPTION
This allows `redis-rack` to function like the rails [:cache_store](https://github.com/rails/rails/blob/4-2-stable/actionpack/lib/action_dispatch/middleware/session/cache_store.rb) by allowing the global lock to be disabled.

The new option is `:use_global_lock` which is `true` by default for backwards compatibility. I'm not sure if you have a convention for option names, default values, or a place you document them, but I'd be happy to rename or make a documentation change with this.

cc @tubbo 