### PR TITLE
Remove rake, appraisal from gemspec executables

### DIFF
--- a/redis-rack.gemspec
+++ b/redis-rack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = []
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'redis-store',   ['< 2', '>= 1.2']


### PR DESCRIPTION
The contents of the bin directory are binstubs to assist development. They are not intended to be shipped with the gem itself. This commit updates the gemspec to ensure that they are not exposed to rubygems as executables for redis-rack, which will fix conflicts with the legitimate rake and appraisal executables provided by those other gems.

Fixes #32, #33.