### PR TITLE
Don't Store Blank Session Keys in Redis

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -20,6 +20,7 @@ module Rack
       end
 
       def generate_unique_sid(session)
+        return generate_sid if session.empty?
         loop do
           sid = generate_sid
           first = with do |c|

--- a/test/rack/session/redis_test.rb
+++ b/test/rack/session/redis_test.rb
@@ -90,6 +90,12 @@ describe Rack::Session::Redis do
     sesion_store.threadsafe?.must_equal(true)
   end
 
+  it "does not store a blank session" do
+    session_store = Rack::Session::Redis.new(incrementor)
+    sid = session_store.generate_unique_sid({})
+    session_store.with { |c| c.get(sid).must_be_nil }
+  end
+
   it "locks the store mutex" do
     mutex = Mutex.new
     mutex.expects(:lock).once


### PR DESCRIPTION
When doing some testing on our application I found that we were storing a lot of blank session keys in Redis. This seemed like a waste of resources so I updated this method to skip storing the blank sessions. 

There was not a specific test written for this method but I am open to writing one if you think it is needed.  Thanks!