### PR TITLE
Only pass two args to setnx

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -24,7 +24,7 @@ module Rack
         loop do
           sid = generate_sid
           first = with do |c|
-            [*c.setnx(sid, session, @default_options)].first
+            [*c.setnx(sid, session)].first
           end
           break sid if [1, true].include?(first)
         end


### PR DESCRIPTION
Since `setnx` has an arity of two, this method call fails when a user provides their own `pool` option.

Relevant docs: https://www.rubydoc.info/github/ezmobius/redis-rb/Redis:setnx