### PR TITLE
Raise Error when `:redis_store` is Incorrect Type

### DIFF
--- a/lib/redis/rack/connection.rb
+++ b/lib/redis/rack/connection.rb
@@ -9,6 +9,10 @@ class Redis
         if @pool && !@pool.is_a?(ConnectionPool)
           raise ArgumentError, "pool must be an instance of ConnectionPool"
         end
+
+        if @store && !@store.is_a?(Redis::Store)
+          raise ArgumentError, "redis_store must be an instance of Redis::Store (currently #{@store.class.name})"
+        end
       end
 
       def with(&block)

--- a/test/redis/rack/connection_test.rb
+++ b/test/redis/rack/connection_test.rb
@@ -56,6 +56,12 @@ class Redis
         conn.store.must_equal(store)
       end
 
+      it "throws an error when provided Redis store is not the expected type" do
+        assert_raises ArgumentError do
+          Connection.new(redis_store: ::Redis.new)
+        end
+      end
+
       it "uses the specified Redis server when provided" do
         conn = Connection.new(redis_server: 'redis://127.0.0.1:6380/1')
 


### PR DESCRIPTION
Passing an object that isn't a `Redis::Store` into the session storage
configuration can cause errors when methods are called with more
arguments than the default Redis client can handle. These additional
arguments are used by `Rack::Session::Redis` to configure the key
namespace and TTL globally in the main configuration, and pass them down
to `Redis::Store` to be appended to the key. An `ArgumentError` will now
be thrown when a `:redis_store` is of a type that isn't a `Redis::Store`
(or a subclass thereof).

Resolves #46