### PR TITLE
Set the TTL correctly on session keys

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -46,7 +46,7 @@ module Rack
 
       def set_session(env, session_id, new_session, options)
         with_lock(env, false) do
-          with { |c| c.set session_id, new_session, options }
+          with { |c| c.set session_id, new_session, ex: options[:expire_after] }
           session_id
         end
       end


### PR DESCRIPTION
Previously, we were passing the whole of the `options` object to the
redis set command, which while not malicious, doesn't actually do
anything since none of those keys are supported. The only valid option
that is exposed in those options would be the expire_after key which we
need to transform into the `ex` option. If there's no expire_after then
the `ex` gets `nil` which then has the same behaviour as before.

Fixes #48 