### PR TITLE
Update gemspec to remove rubyforge_project

### DIFF
--- a/redis-rack.gemspec
+++ b/redis-rack.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Redis Store for Rack applications}
   s.license     = 'MIT'
 
-  s.rubyforge_project = 'redis-rack'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = []


### PR DESCRIPTION
It is deprecated or removed already

Original warning message:
Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.