### PR TITLE
Pass options to session redis as Hash

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -24,7 +24,7 @@ module Rack
         loop do
           sid = generate_sid
           first = with do |c|
-            [*c.setnx(sid.private_id, session, @default_options)].first
+            [*c.setnx(sid.private_id, session, @default_options.to_hash)].first
           end
           break sid if [1, true].include?(first)
         end
@@ -44,9 +44,9 @@ module Rack
         end
       end
 
-      def write_session(req, sid, new_session, options)
+      def write_session(req, sid, new_session, options = {})
         with_lock(req, false) do
-          with { |c| c.set sid.private_id, new_session, options }
+          with { |c| c.set(sid.private_id, new_session, options.to_hash) }
           sid
         end
       end
@@ -65,7 +65,7 @@ module Rack
         @default_options.fetch(:threadsafe, true)
       end
 
-      def with_lock(req, default=nil)
+      def with_lock(req, default = nil)
         @mutex.lock if req.multithread? && threadsafe?
         yield
       rescue Errno::ECONNREFUSED


### PR DESCRIPTION
This is a follow-up to https://github.com/redis-store/redis-store/pull/333. The `options` object passed in to `write_session` can be a [`ActionDispatch::Request::Session::Options`](https://github.com/rails/rails/blob/0601a9f9aa99bfda26578ab86533bb215f1ee463/actionpack/lib/action_dispatch/request/session.rb#L34-L61) object, which doesn't respond to `key?`. Fix that by converting the options to a Hash before passing along.

I'm not sure how to best write tests for this.