### PR TITLE
Optimize pooled? by value memoization

### DIFF
--- a/lib/redis/rack/connection.rb
+++ b/lib/redis/rack/connection.rb
@@ -1,6 +1,8 @@
 class Redis
   module Rack
     class Connection
+      POOL_KEYS = %i[pool pool_size pool_timeout].freeze
+
       def initialize(options = {})
         @options = options
         @store = options[:redis_store]
@@ -24,7 +26,9 @@ class Redis
       end
 
       def pooled?
-        [:pool, :pool_size, :pool_timeout].any? { |key| @options.key?(key) }
+        return @pooled if defined?(@pooled)
+
+        @pooled = POOL_KEYS.any? { |key| @options.key?(key) }
       end
 
       def pool


### PR DESCRIPTION
Since `@options` shouldn't change we can memoize it. This change allows to avoid creating a new array every time we call `pooled?` and also reduces the number of iterations `%i[pool pool_size pool_timeout]` to just one.

```ruby
original = Redis::Rack::Connection.new
optimized = Redis::Rack::ConnectionOpt.new

[:ips, :memory].each do |type|
  Benchmark.public_send(type) do |x|
    x.report('original') do
      100.times { original.pooled? }
    end
    x.report('optimized') do
      100.times { optimized.pooled? }
    end

    x.compare!
  end
end

Warming up --------------------------------------
            original     4.493k i/100ms
           optimized    16.942k i/100ms
Calculating -------------------------------------
            original     46.336k (± 2.3%) i/s -    233.636k in   5.044872s
           optimized    172.895k (± 2.1%) i/s -    880.984k in   5.097786s

Comparison:
           optimized:   172895.5 i/s
            original:    46336.1 i/s - 3.73x  (± 0.00) slower

Calculating -------------------------------------
            original     4.000k memsize (     0.000  retained)
                       100.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:          0 allocated
            original:       4000 allocated - Infx more
```