### PR TITLE
Support Rack v3

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -66,7 +66,7 @@ module Rack
       end
 
       def with_lock(req, default = nil)
-        @mutex.lock if req.multithread? && threadsafe?
+        @mutex.lock if threadsafe?
         yield
       rescue Errno::ECONNREFUSED
         if $VERBOSE

--- a/redis-rack.gemspec
+++ b/redis-rack.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'redis-store',   ['< 2', '>= 1.2']
-  s.add_runtime_dependency 'rack',          '>= 2.0.8', '< 3'
+  s.add_runtime_dependency 'rack-session',  '>= 0.2.0'
 
   s.add_development_dependency 'rake',     '>= 12.3.3'
   s.add_development_dependency 'bundler',  '> 1', '< 3'


### PR DESCRIPTION
Rack 3 uses a separate gem named `rack-session` for the stuff we depend on, so change the dependencies to use that gem instead of `rack` itself, and make a couple API changes to facilitate supporting this new Rack version.

Fixes: #71