### PR TITLE
Fixed a bug that ConnectionPool holds the same Redis client.

### DIFF
--- a/lib/redis/rack/connection.rb
+++ b/lib/redis/rack/connection.rb
@@ -32,11 +32,11 @@ class Redis
       end
 
       def pool
-        @pool ||= ConnectionPool.new(pool_options) { store } if pooled?
+        @pool ||= ConnectionPool.new(pool_options) { build_store } if pooled?
       end
 
       def store
-        @store ||= Redis::Store::Factory.create(@options[:redis_server])
+        @store ||= build_store
       end
 
       def pool_options
@@ -44,6 +44,12 @@ class Redis
           size: @options[:pool_size],
           timeout: @options[:pool_timeout]
         }.reject { |key, value| value.nil? }.to_h
+      end
+
+      private
+
+      def build_store
+        Redis::Store::Factory.create(@options[:redis_server])
       end
     end
   end


### PR DESCRIPTION
When `pool_size` or `pool_timeout` is passed as an option, `Redis::Rack::Connection` builds a `ConnectionPool`. `ConnectionPool` will execute a given block when there are not enough connections. However, since the calling store is cached in an instance variable, all connections held by the `ConnectionPool` are actually same objects.

It seems like something fatal would occur, but since there are no reports in the issues, maybe the existing implementation is no problem.

NOTE: This bug does not affect the following users:
- Users who specify `threadsafe: true`.
- Users who do not pass the `threadsafe` option.
- Users who directly pass the pool as options, such as `{ pool: ConnectionPool.new(...) }`.